### PR TITLE
hotfiix:修复Class "Hyperf\Coroutine\Locker" not found

### DIFF
--- a/src/MetaGenerator/RedisMetaGenerator.php
+++ b/src/MetaGenerator/RedisMetaGenerator.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Hyperf\Snowflake\MetaGenerator;
 
 use Hyperf\Contract\ConfigInterface;
-use Hyperf\Coroutine\Locker;
+use Hyperf\Utils\Coroutine\Locker;
 use Hyperf\Redis\RedisProxy;
 use Hyperf\Snowflake\ConfigurationInterface;
 use Hyperf\Snowflake\MetaGenerator;


### PR DESCRIPTION
修复
Error: Class "Hyperf\Coroutine\Locker" not found in /opt/www/cepf-oms-sw/vendor/hyperf/snowflake/src/MetaGenerator/RedisMetaGenerator.php:38

issues:
https://github.com/hyperf/hyperf/issues/5637